### PR TITLE
chore(autoscaling): add troubleshooting guides

### DIFF
--- a/content/cecg-idp/app/ingress.md
+++ b/content/cecg-idp/app/ingress.md
@@ -39,4 +39,4 @@ The important parts are:
 
 Your service will now be available over the Internet over TLS.
 
-To have a deeper understanding of how the Plaform Ingress feature is designed, check the [Platform Ingress Overview.](../platform/platform-ingress.md)
+To have a deeper understanding of how the Plaform Ingress feature is designed, check the [Platform Ingress Overview.](../platform/platform-ingress)

--- a/content/cecg-idp/app/tenancy.md
+++ b/content/cecg-idp/app/tenancy.md
@@ -73,7 +73,7 @@ betaFeatures:
 * `environments` which of the environments in [Environments Repo]({{< param environmentRepo >}}) you want to deploy to 
 * `adminGroup` - will get permission to do all actions in the created namespaces
 * `readonlyGroup` -  will get read only access to the created namespaces
-* `repos` - Your [application](./new-app.md) URL. All `repos` GitHub actions will get permission to deploy to the created namespaces for implementing your application's [Path to Production](../p2p) aka CI/CD
+* `repos` - Your [application](./new-app) URL. All `repos` GitHub actions will get permission to deploy to the created namespaces for implementing your application's [Path to Production](../p2p) aka CI/CD
 * `cloudAccess` - generates cloud provider specific machine identities for kubernetes service accounts to impersonate/assume. Note that the `kubernetesServiceAccounts` are constructed like `<namespace>/<kubernetesServiceAccount>` so make sure these match with what your application is doing. This Kubernetes Service Account is controlled and created by the App and configured to use the GCP service account created by this configuration.
 * `infrastructure` - allows you to configure projects to be attached to the current one's shared VPC, allowing you to use Private Service Access connections to databases in your own projects. This will attach your project to the one on the environment. 
 * `betaFeatures` - enables certain beta features for tenants:

--- a/content/cecg-idp/app/troubleshooting.md
+++ b/content/cecg-idp/app/troubleshooting.md
@@ -19,7 +19,7 @@ gke-sandbox-gcp-sandbox-gcp-pool-18d01f3c-xhd8   174m         9%     2047Mi     
 If the node cpu/memory usage is high, it's possible the container runtime is struggling to find enough resources to be able to run the container.
 
 ### Resolution
-Ensure that your pod has [cpu/memory requests set](./resources.md). This will allow the kube scheduler to to place your pods on better balanced nodes.
+Ensure that your pod has [cpu/memory requests set](./resources). This will allow the kube scheduler to to place your pods on better balanced nodes.
 
 ## P2P GCP Auth Fail
 

--- a/content/cecg-idp/p2p/extended-test/_index.md
+++ b/content/cecg-idp/p2p/extended-test/_index.md
@@ -60,5 +60,5 @@ jobs:
 This task will get the latest version that's on the `/extended-test` registry and execute the extended tests. If these are successful, it will promote the image to `prod`.
 
 ## Setup
-See the [fast-feedback](../fast-feedback/fast-feedback.md)
+See the [fast-feedback](../fast-feedback/fast-feedback)
 

--- a/content/cecg-idp/p2p/how-tos/connect-to-cloudsql.md
+++ b/content/cecg-idp/p2p/how-tos/connect-to-cloudsql.md
@@ -7,7 +7,7 @@ pre = ""
 
 # Connectivity & Authentication
 
-With CloudSQL you can configure the connectivity and the authentication via IAM Service Accounts. For connectivity, please follow the setup [access cloud infrastructure](../../app/accessing-cloud-infra.md)
+With CloudSQL you can configure the connectivity and the authentication via IAM Service Accounts. For connectivity, please follow the setup [access cloud infrastructure](../../app/accessing-cloud-infra)
 
 
 ## Auth

--- a/content/cecg-idp/platform/platform-ingress.md
+++ b/content/cecg-idp/platform/platform-ingress.md
@@ -102,7 +102,7 @@ spec:
               number: 3000
 ```
 
-For more information on how to use this, please look at the [App Ingress section.](../app/ingress.md)
+For more information on how to use this, please look at the [App Ingress section.](../app/ingress)
 
 ## Autoscaling
 

--- a/content/cecg-idp/platform/troubleshooting.md
+++ b/content/cecg-idp/platform/troubleshooting.md
@@ -55,7 +55,7 @@ There are times where a node can be throttled e.g. 96% memory usage when other n
 It is highly likely that pods running on that node do not have memory/cpu requests set. This causes kube scheduler to place significant load on one node as it uses the requests to target what nodes pods should be placed on.
 
 ### Resolution
-Set [resource requests](../app/resources.md) for your application workloads to allow the kube scheduler better place your pods on nodes with appropiate capacity. For example if you request 2Gi memory for your pod, the scheduler will guarantee finding a node that has that capacity. 
+Set [resource requests](../app/resources) for your application workloads to allow the kube scheduler better place your pods on nodes with appropiate capacity. For example if you request 2Gi memory for your pod, the scheduler will guarantee finding a node that has that capacity. 
 
 ## Deployment Failures
 


### PR DESCRIPTION
Add documentation around troubleshooting autoscaling. This is very useful for clients as they aren't familiar on how autoscaling works and have encountered issues where workloads were not being scheduled