### PR TITLE
documentation for NAT Gateway static IP allocation

### DIFF
--- a/content/platform/alert-runbooks.md
+++ b/content/platform/alert-runbooks.md
@@ -122,7 +122,7 @@ to 100%, some outbound requests will be affected.
 
 {{% notice warning %}}
 Utilisation doesn't have to reach 100% for requests to be affected. NAT Gateway will try to allocate at least the number
-of ports specified in `network.public_nat_gateway.min_ports_per_vm` configuration. If there are not enough ports available to
+of ports specified in `network.publicNatGateway.minPortsPerVm` configuration. If there are not enough ports available to
 satisfy this value, no ports will be allocated to VM in need.
 {{% /notice %}}
 

--- a/content/platform/alert-runbooks.md
+++ b/content/platform/alert-runbooks.md
@@ -10,7 +10,7 @@ pre = ""
 This contains a collection of runbooks that need to be followed for each alert raised on the platform.
 Each alert should contain a short description and a deep link to the corresponding alert in this document.
 
-##### KubePodCannotConnectToInternet
+#### KubePodCannotConnectToInternet
 
 1. Is this affecting pods network and node network too?
 
@@ -25,11 +25,12 @@ Each alert should contain a short description and a deep link to the correspondi
     curl https://www.google.com
     ```
 
-   Is that fails, check your NAT Gateway.
+   Is that fails, check your NAT Gateway. Dashboard can be found in `platform-monitoring/NAT Gateway` dashboard in
+   Grafana.
 
 2. Is the Cloud NAT configured correctly?
 
-##### ClusterAutoscalerNoScaleUp
+#### ClusterAutoscalerNoScaleUp
 
 Node auto-provisioning did not provision any node pool for the pending pod because doing so would violate resource
 limits.
@@ -44,7 +45,7 @@ log_id("container.googleapis.com/cluster-autoscaler-visibility") AND
 
 Review and update cluster-wide minimal resource limits set for cluster auto-scaler.
 
-##### KubeHpaReplicasMismatch
+#### KubeHpaReplicasMismatch
 
 Horizontal Pod Autoscaler has not matched the desired number of replicas for longer than 15 minutes.
 HPA was unable to schedule desired number of pods.
@@ -57,7 +58,7 @@ Check why HPA was unable to scale:
 
 In case of cluster-autoscaler you may need to set up preemptive pod pools to ensure nodes are created on time.
 
-##### KubeHpaMaxedOut
+#### KubeHpaMaxedOut
 
 Horizontal Pod Autoscaler (HPA) has been running at max replicas for longer than 15 minutes.
 HPA won’t be able to add new pods and thus scale application.
@@ -75,7 +76,7 @@ If using custom metrics then fine tune how app scales accordingly to it.
 
 Use performance tests to see how the app scales.
 
-##### ContainerInErrorState
+#### ContainerInErrorState
 
 Container is not starting up, stuck in waiting state.
 
@@ -104,3 +105,44 @@ Container is not starting up, stuck in waiting state.
 4. Can the pod be scheduled? Check request/limits on the container and ensure there is enough in the cluster. More info
    on debugging can be found
    in [GKE docs](https://cloud.google.com/kubernetes-engine/docs/troubleshooting#PodUnschedulable)
+
+#### NatGatewayHighPortUtilisation
+
+##### Meaning
+
+High port utilisation by NAT Gateway, port allocation reached 70%. Each external IP address provides 64,512 available
+ports that are shared by all VMs. Each port corresponds to a connection to unique destination address (IP:PORT:
+PROTOCOL). When NAT Gateway runs out of free ports, it will start dropping outbound packets (requests going out to
+the internet).
+
+##### Impact
+
+No outbound requests are affected at this point; however, you're getting closer to the limit. Once utilisation is closer
+to 100%, some outbound requests will be affected.
+
+{{% notice warning %}}
+Utilisation doesn't have to reach 100% for requests to be affected. NAT Gateway will try to allocate at least the number
+of ports specified in `network.public_nat_gateway.min_ports_per_vm` configuration. If there are not enough ports available to
+satisfy this value, no ports will be allocated to VM in need.
+{{% /notice %}}
+
+##### Diagnosis & Mitigation
+
+Follow [NAT Gateway IP Allocation Failures](../troubleshooting#nat-gateway-ip-allocation-failures) section.
+
+#### NatGatewayIpAllocationFailed
+
+##### Meaning
+
+Failure in allocating NAT IPs to any VM in the NAT gateway. In result, services residing on affected VM's will not be
+able to reach the internet. NAT Gateway allocates single IP to multiple VM's. When there are not enough available NAT
+source IP addresses and source port tuples (IP:PORT:PROTOCOL), the NAT Gateway won't be able to service any new outbound
+connections.
+
+##### Impact
+
+Some current outbound requests are affected.
+
+##### Diagnosis & Mitigation
+
+Follow [NAT Gateway IP Allocation Failures](../troubleshooting#nat-gateway-ip-allocation-failures) section.

--- a/content/platform/nat-gateway.md
+++ b/content/platform/nat-gateway.md
@@ -32,25 +32,25 @@ use [Manual NAT IP address assignment with dynamic port allocation](https://clou
 
 ```
 network:
-  public_nat_gateway: # [Optional] configuration for the NAT Gateway
-    ips: 2 # [Required] numer of IP addresses to allocate
+  publicNatGateway: # [Optional] configuration for the NAT Gateway
+    ipCount: 2 # [Required] numer of IP addresses to allocate
     logging: ERRORS_ONLY # [Optional] enable logging, available values: ERRORS_ONLY,TRANSLATIONS_ONLY,ALL, when not provided no logging is enabled, we recommend setting to ERRORS_ONLY
-    min_ports_per_vm: 64 # [Optional] min number of ports per VM, when not provided default (64) is used
-    max_ports_per_vm: 128 # [Optional] max number of port per VM, when not provided default (32,768) is used
-    tcp_established_idle_timeout_sec: 1200 # [Optional] timeout (in seconds) for TCP established connections (default 1200), only update when necessary, otherwise leave default
-    tcp_transitory_idle_timeout_sec: 30 # [Optional] timeout (in seconds) for TCP transitory connections (default 30), only update when necessary, otherwise leave default
-    tcp_time_wait_timeout_sec: 120 # [Optional] timeout (in seconds) for TCP connections that are in TIME_WAIT state (default 120), only update when necessary, otherwise leave default
+    minPortsPerVm: 64 # [Optional] min number of ports per VM, when not provided default (64) is used
+    maxPortsPerVm: 128 # [Optional] max number of port per VM, when not provided default (32,768) is used
+    tcpEstablishedIdleTimeoutSec: 1200 # [Optional] timeout (in seconds) for TCP established connections (default 1200), only update when necessary, otherwise leave default
+    tcpTransitoryIdleTimeoutSec: 30 # [Optional] timeout (in seconds) for TCP transitory connections (default 30), only update when necessary, otherwise leave default
+    tcpTimeWaitTimeoutSec: 120 # [Optional] timeout (in seconds) for TCP connections that are in TIME_WAIT state (default 120), only update when necessary, otherwise leave default
 ```
 
 #### Recommended overrides
 
 ```
 network:
-  public_nat_gateway: # [Optional] configuration for the NAT Gateway
-    ips: <numbers of IPs to allocate>
+  publicNatGateway: # [Optional] configuration for the NAT Gateway
+    ipCount: <numbers of IPs to allocate>
     logging: ERRORS_ONLY # enable logging for packet drops due to NAT IP allocation
-    min_ports_per_vm: <set min number of ports per VM>
-    max_ports_per_vm: <set max number of ports per VM>
+    minPortsPerVm: <set min number of ports per VM>
+    maxPortsPerVm: <set max number of ports per VM>
 ```
 
 ## View assigned IP addresses
@@ -95,7 +95,7 @@ for further details.
 
 All IP addresses are created sequentially, following naming convention `<env>-nat-ext-ip-<number>`, numbered from 0 to
 X. During IP address reservation the platform stores those IPs in an ordered list. We recommend that you remove one IP
-address at a time. Decreasing `network.public_nat_gateway.ips` number by one causes removal of a last IP address in GCP,
+address at a time. Decreasing `network.publicNatGateway.ipCount` number by one causes removal of a last IP address in GCP,
 therefore **make sure you drain last IP address**. In case you remove/drain the wrong address, the release fails as you
 cannot delete addresses that are still allocated to NAT Gateway.
 
@@ -109,18 +109,18 @@ cannot delete addresses that are still allocated to NAT Gateway.
     2. enable NAT Logging by:
    ```
    network:
-     public_nat_gateway:
+     publicNatGateway:
        logging: ALL
        ...
    ```
    and checking that there are no logs for open connections associated to drained IP address.
 4. Remove drained IP address assignment from NAT Gateway in UI.
-5. Update `network.public_nat_gateway` configuration and release:
+5. Update `network.publicNatGateway` configuration and release:
 
    ```
    network:
-     public_nat_gateway:
-       ips: 2 # decrease this number to desired number of IP addresses
+     publicNatGateway:
+       ipCount: 2 # decrease this number to desired number of IP addresses
        ...
    ```
 6. Notify any third parties on source IP changes for outbound connections so they can update their allowlists.
@@ -167,7 +167,7 @@ in [Switch assignment method](https://cloud.google.com/nat/docs/ports-and-addres
    ```
    curl -I www.google.com
    ```
-4. Remove `network.public_nat_gateway` section from platform environment configuration and release.
+4. Remove `network.publicNatGateway` section from platform environment configuration and release.
 
 ### Troubleshooting
 

--- a/content/platform/nat-gateway.md
+++ b/content/platform/nat-gateway.md
@@ -53,6 +53,11 @@ network:
     max_ports_per_vm: <set max number of ports per VM>
 ```
 
+## View assigned IP addresses
+
+To view all assigned IP addresses to the NAT Gateway
+follow [View NAT IP addresses assigned to a gateway](https://cloud.google.com/nat/docs/set-up-manage-network-address-translation#view_nat_ip_addresses_assigned_to_a_gateway)
+
 ## Increase allocated number of IP addresses
 
 {{% notice warning %}}

--- a/content/platform/nat-gateway.md
+++ b/content/platform/nat-gateway.md
@@ -1,0 +1,172 @@
++++
+title = "Outbound Connections"
+weight = 2
+chapter = false
+pre = ""
++++
+
+## Outbound Connections
+
+Cloud NAT (network address translation) lets certain resources in GCP create outbound connections to the
+internet or to other Virtual Private Cloud (VPC) networks, on-premises networks, or other cloud provider networks. Cloud
+NAT supports address translation for established inbound response packets only. It does not allow unsolicited inbound
+connections.
+
+## Outbound IP
+
+By default, GCP allocates IP addresses automatically. The IP addresses are managed by GCP, added or removed based on the
+outbound traffic. This is the default platform configuration. With automatic allocation, you cannot predict the next IP
+address that is allocated. If you depend on knowing the set of possible NAT IP addresses ahead of time (for example, to
+create an allowlist), you should use manual NAT IP address assignment instead.
+
+## Static (Manual) Outbound IPs Assignment
+
+The platform provides a feature that enables allocation of a number of static IP addresses that can be reserved upfront.
+When using that feature, you must calculate the number of regional external IP addresses that you need for the
+NAT gateway. If your gateway runs out of NAT IP addresses, it drops packets. You can increase or decrease the
+number of allocated static IP addresses by updating platform environment configuration. Those IP addresses are reserved
+and will remain so until you delete them. To enable this feature, we
+use [Manual NAT IP address assignment with dynamic port allocation](https://cloud.google.com/nat/docs/ports-and-addresses#addresses)
+
+### Platform environment configuration
+
+```
+network:
+  public_nat_gateway: # [Optional] configuration for the NAT Gateway
+    ips: 2 # [Required] numer of IP addresses to allocate
+    logging: ERRORS_ONLY # [Optional] enable logging, available values: ERRORS_ONLY,TRANSLATIONS_ONLY,ALL, when not provided no logging is enabled, we recommend setting to ERRORS_ONLY
+    min_ports_per_vm: 64 # [Optional] min number of ports per VM, when not provided default (64) is used
+    max_ports_per_vm: 128 # [Optional] max number of port per VM, when not provided default (32,768) is used
+    tcp_established_idle_timeout_sec: 1200 # [Optional] timeout (in seconds) for TCP established connections (default 1200), only update when necessary, otherwise leave default
+    tcp_transitory_idle_timeout_sec: 30 # [Optional] timeout (in seconds) for TCP transitory connections (default 30), only update when necessary, otherwise leave default
+    tcp_time_wait_timeout_sec: 120 # [Optional] timeout (in seconds) for TCP connections that are in TIME_WAIT state (default 120), only update when necessary, otherwise leave default
+```
+
+#### Recommended overrides
+
+```
+network:
+  public_nat_gateway: # [Optional] configuration for the NAT Gateway
+    ips: <numbers of IPs to allocate>
+    logging: ERRORS_ONLY # enable logging for packet drops due to NAT IP allocation
+    min_ports_per_vm: <set min number of ports per VM>
+    max_ports_per_vm: <set max number of ports per VM>
+```
+
+## Increase allocated number of IP addresses
+
+{{% notice warning %}}
+Allocating more IP addresses might cause source IP changes to existing services for outbound requests. If third party
+clients allowlisted specific IPs, they'll need to update their allowlist accordingly.
+{{% /notice %}}
+
+1. Calculate the number of IPs required. To understand your current NAT Gateway usage,
+   see `NAT Gateway` dashboard in Grafana.
+   For example of IP/ports calculations,
+   see [Port reservation example](https://cloud.google.com/nat/docs/ports-and-addresses#port-reservation-examples). To
+   define min number of ports per VM,
+   see [Choose a minimum number of ports per VM](https://cloud.google.com/nat/docs/tune-nat-configuration#choose-minimum)
+2. Update environment configuration file as
+   per [Platform environment configuration](#platform-environment-configuration)
+
+Cloud NAT gateway will dynamically allocate different number of ports per VM, based on the VM's usage. Min and max
+ports settings are optional; however, it is strongly recommended to set those values to ensure strong tenant
+isolation (misbehaving services won't acquire all available connections). For more information on port allocation
+see [Ports](https://cloud.google.com/nat/docs/ports-and-addresses#ports) section.
+
+{{% notice note %}}
+Please note that NAT Gateway has GCP imposed limits, see [NAT limits](https://cloud.google.com/nat/quota#limits) for
+details.
+{{% /notice %}}
+
+## Decrease allocated number of IP addresses
+
+{{% notice warning %}}
+Increasing the number of IPs is a safe operation; the existing connections won't be affected, however, decreasing the
+value without draining the connections first will cause connection being terminated immediately.
+See [Impact of tuning NAT configurations on existing NAT connections](https://cloud.google.com/nat/docs/tune-nat-configuration#impact-nat-tuning-existing-conns)
+for further details.
+{{% /notice %}}
+
+All IP addresses are created sequentially, following naming convention `<env>-nat-ext-ip-<number>`, numbered from 0 to
+X. During IP address reservation the platform stores those IPs in an ordered list. We recommend that you remove one IP
+address at a time. Decreasing `network.public_nat_gateway.ips` number by one causes removal of a last IP address in GCP,
+therefore **make sure you drain last IP address**. In case you remove/drain the wrong address, the release fails as you
+cannot delete addresses that are still allocated to NAT Gateway.
+
+1. Ensure you'll choose the last created IP address; this is the address with the greatest number, following naming
+   convention `<env>-nat-ext-ip-<number>`
+2. Drain existing connections,
+   see [Drain external IP addresses associated with NAT](https://cloud.google.com/nat/docs/set-up-manage-network-address-translation#draining)
+3. Confirm that all connections associated with the IP addressed drained are closed. You can do so by
+    1. checking `Port Allocation[NAT Gateway]` graph
+       in `NAT Gateway` Grafana dashboard, there should be no port allocation from drained IP.
+    2. enable NAT Logging by:
+   ```
+   network:
+     public_nat_gateway:
+       logging: ALL
+       ...
+   ```
+   and checking that there are no logs for open connections associated to drained IP address.
+4. Remove drained IP address assignment from NAT Gateway in UI.
+5. Update `network.public_nat_gateway` configuration and release:
+
+   ```
+   network:
+     public_nat_gateway:
+       ips: 2 # decrease this number to desired number of IP addresses
+       ...
+   ```
+6. Notify any third parties on source IP changes for outbound connections so they can update their allowlists.
+
+## Migrate to static (manual) IP allocation
+
+{{% notice warning %}}
+Switching IP assignment method is disruptive, and it breaks all active NAT connections. Further info can be found
+in [Switch assignment method](https://cloud.google.com/nat/docs/ports-and-addresses#switching-nat-ip-method)
+{{% /notice %}}
+
+1. Update chosen environment configuration file as
+   per [Platform environment configuration](#platform-environment-configuration)
+2. Validate changes in
+   GCP [IP addresses](https://console.cloud.google.com/networking/addresses/list), [NAT Gateway](https://console.cloud.google.com/net-services/nat/list)
+3. Test outbound connection from the cluster
+   ```
+   kubectl run tmp-shell --rm -it --image nicolaka/netshoot -- /bin/bash # pod network
+   kubectl run tmp-shell --rm -it --image nicolaka/netshoot --overrides='{ "spec": { "hostNetwork" : true }  }' -- /bin/bash # host network
+   ```
+   Once in the container run (if it fails, double check that Google is up
+   on [uptime](https://uptime.com/upstatus/google.co.uk?start=20240821&end=20240821))
+   ```
+   curl -I www.google.com
+   ```
+
+## Migrate to automatic IP allocation
+
+{{% notice warning %}}
+Switching IP assignment method is disruptive, and it breaks all active NAT connections. Further info can be found
+in [Switch assignment method](https://cloud.google.com/nat/docs/ports-and-addresses#switching-nat-ip-method)
+{{% /notice %}}
+
+1. Repeat [Decrease allocated number of IP addresses](#decrease-allocated-number-of-ip-addresses) until you'll be left
+   with a single IP
+2. Manually update NAT Gateway configuration in GCP UI to set `Cloud NAT IP addresses` field to `Automatic`, then save.
+3. Test outbound connection from the cluster
+   ```
+   kubectl run tmp-shell --rm -it --image nicolaka/netshoot -- /bin/bash # pod network
+   kubectl run tmp-shell --rm -it --image nicolaka/netshoot --overrides='{ "spec": { "hostNetwork" : true }  }' -- /bin/bash # host network
+   ```
+   Once in the container run (if it fails, double check that Google is up
+   on [uptime](https://uptime.com/upstatus/google.co.uk?start=20240821&end=20240821))
+   ```
+   curl -I www.google.com
+   ```
+4. Remove `network.public_nat_gateway` section from platform environment configuration and release.
+
+### Troubleshooting
+
+For troubleshooting Platform NAT Gateway see
+Follow [NAT Gateway IP Allocation Failures](../troubleshooting#nat-gateway-ip-allocation-failures) section.
+For more generic information on common issues and how to solve them with Cloud NAT
+see [Troubleshooting guide](https://cloud.google.com/nat/docs/troubleshooting)

--- a/content/platform/troubleshooting.md
+++ b/content/platform/troubleshooting.md
@@ -13,12 +13,15 @@ pre = ""
 0/7 nodes are available: 7 Insufficient memory. preemption: 0/7 nodes are available: 1 Insufficient memory, 6 No preemption victims found for incoming pod.
 ```
 
-Pods are stuck in `Pending` state. 
+Pods are stuck in `Pending` state.
 
-Total memory requests for pods have exceeded the maximum memory that is allowed as part of node autoscaling in the cluster. 
+Total memory requests for pods have exceeded the maximum memory that is allowed as part of node autoscaling in the
+cluster.
 
 #### Resolution
+
 Update `config.yaml` to increase the memory limit of the cluster autoscaling. Example:
+
 ```
 cluster:
   gcp:
@@ -35,12 +38,14 @@ After the limits have been applied to the cluster, the pod should transition fro
 0/7 nodes are available: 7 Insufficient cpu. preemption: 0/7 nodes are available: 1 Insufficient cpu, 6 No preemption victims found for incoming pod.
 ```
 
-Pods are stuck in `Pending` state. 
+Pods are stuck in `Pending` state.
 
 Total cpu requests for pods have exceeded the maximum cpu that is allowed for node autoscaling.
 
 ### Resolution
+
 Update `config.yaml` to increase the cpu limit of the cluster autoscaling. Example:
+
 ```
 cluster:
   gcp:
@@ -50,18 +55,24 @@ cluster:
 ```
 
 ## Node Imbalance
-There are times where a node can be throttled e.g. 96% memory usage when other nodes have more than enough capacity to accomodate extra workloads.
 
-It is highly likely that pods running on that node do not have memory/cpu requests set. This causes kube scheduler to place significant load on one node as it uses the requests to target what nodes pods should be placed on.
+There are times where a node can be throttled e.g. 96% memory usage when other nodes have more than enough capacity to
+accomodate extra workloads.
+
+It is highly likely that pods running on that node do not have memory/cpu requests set. This causes kube scheduler to
+place significant load on one node as it uses the requests to target what nodes pods should be placed on.
 
 ### Resolution
-Set [resource requests](../../app/resources) for your application workloads to allow the kube scheduler better place your pods on nodes with appropiate capacity. For example if you request 2Gi memory for your pod, the scheduler will guarantee finding a node that has that capacity. 
+
+Set [resource requests](../../app/resources) for your application workloads to allow the kube scheduler better place
+your pods on nodes with appropiate capacity. For example if you request 2Gi memory for your pod, the scheduler will
+guarantee finding a node that has that capacity.
 
 ## Deployment Failures
 
 #### Local port [xxxx] is not available
 
-A local port is used locally on the GitHub agent to IAP proxy to the Kubernetes API server. 
+A local port is used locally on the GitHub agent to IAP proxy to the Kubernetes API server.
 Sometimes a randomly selected port is not available.
 
 #### Logs
@@ -77,17 +88,22 @@ The job can be re-run using re-run failed jobs
 
 ## Ingress / TLS Failures
 
-#### A new ingress domain is not working 
+#### A new ingress domain is not working
 
 When adding a new ingress domain the platform:
-* Creates a Cloud DNS Managed Zone. You need to set up delegation for this domain so that Cloud DNS becomes the Name server. 
 
+* Creates a Cloud DNS Managed Zone. You need to set up delegation for this domain so that Cloud DNS becomes the Name
+  server.
 
-#### IPs not being whitelisted by traefik
-You have configured to whitelist IPs using traefik middlewares but are still getting forbidden when accessing endpoints from a valid IP address.
+#### IPs not being allowlisted by traefik
+
+You have configured to allowlist IPs using traefik middlewares but are still getting forbidden when accessing endpoints
+from a valid IP address.
 
 ##### Enable JSON logs
+
 Edit traefik deployment to add the arguments:
+
 ```
 kind: Deployment
 metadata:
@@ -110,17 +126,18 @@ kubectl logs -f deployment/traefik -n platform-ingress
 
 Logs:
 
-{"level":"debug","middlewareName":"platform-ingress-ready-ipwhitelist@kubernetescrd","middlewareType":"IPWhiteLister","msg":"Accepting IP 86.160.248.78","time":"2024-08-07T22:03:23Z"}
+  { "level": "debug","middlewareName": "platform-ingress-ready-ipwhitelist@kubernetescrd","middlewareType": "IPWhiteLister","msg": "Accepting IP 86.160.248.78","time": "2024-08-07T22:03:23Z" }
 ```
 
 ##### Check Load Balancer logs
+
 On the Google Console navigate to Logging Explorer navigate and run the following query
+
 ```
 resource.type="http_load_balancer" resource.labels.project_id="<your-gcp-project-id>"
 ```
 
 {{< figure src="/images/troubleshooting/loadbalancer_logs.png" title="Load Balancer Logs" >}}
-
 
 #### Actions
 
@@ -154,3 +171,107 @@ kubectl get certificates -n platform-ingress
 kubectl get certificaterequests -n platform-ingress
 kubectl describe gateway traefik -n platform-ingress
 ```
+
+### NAT Gateway IP Allocation Failures
+
+1. Are there not enough IPs allocated? Validate the root cause:
+    1. Single service is keeping a lot of connections open
+        1. Go to
+           Grafana `platform-monitoring/NAT Gateway` dashboard and check:
+            1. which VM's have unusual high open connections,
+            2. which VM's have unusual high number of allocated ports
+            3. correlate this information
+               with `Network Received by Namespace` graph
+               in `platform-monitoring/Kubernetes/Views/Global` dashboard on Grafana. To find namespace that uses most
+               network bandwidth, then check which pod belongs to that namespace in `Network Bandwith` graph in
+               `platform-monitoring/Kubernetes/Views/Pods`.
+        2. [Optional] Enable NAT Gateway logging if not already enabled. Logging provides more detailed information on
+           existing connections. To enable logs update `network.public_nat_gateway.logging` value to one of `ERRORS_ONLY`,
+           `TRANSLATIONS_ONLY`, `ALL`:
+           ```
+           network:
+             public_nat_gateway:
+               logging: TRANSLATIONS_ONLY - update to desired logging level
+           ```
+           See [Configure logging](https://cloud.google.com/nat/docs/monitoring) for log level explanation.
+    2. Cluster Autoscaller is creating an excessive number of VMs. Validate in GCP dashboard, node-pools, metrics
+    3. The Cluster grew naturally and more source NAT IPs are required. If above are not causing the issue, validate
+       that there is a valid reason for more IPs to be reserved and attached to the NAT Gateway. Look at long-term
+       trends of services, node, port allocation growth.
+
+   {{% notice warning %}}
+   Allocating more IP addresses might cause source IP changes to existing services for outbound requests. If third party
+   clients allowlisted specific IPs, they'll need to update their allowlist accordingly.
+   {{% /notice %}}
+
+   Increase the number of IPs allocated to NAT Gateway. Update number of IPs in your
+   `environments/<env_name>/config.yaml` file:
+   ```
+   network:
+     public_nat_gateway:
+       ips: <number of IP's allocated> - increase this value to desired number of IP's
+   ```
+   Release the change and validate that port utilisation went down below 70%.
+
+2. Do you allocate too many min ports per VM?
+    1. Go to Grafana `platform-monitoring/NAT Gateway` dashboard and validate allocated ports per VM against used ports
+       per VM. Ensure to extend time span to take into account all traffic spikes. If most of the time ports are being
+       allocated but not used you can decrease the `min_ports_per_vm` setting in `environments/<env_name>/config.yaml`
+       file:
+       ```
+       network:
+         public_nat_gateway:
+           min_ports_per_vm: <min number of ports allocated to single VM> - decrease this value to release ports
+       ```
+       See [Choose a minimum number of ports per VM](https://cloud.google.com/nat/docs/tune-nat-configuration#choose-minimum)
+       for further details.
+    2. If all ports are utilised, check if you
+       can [Reduce your port usage](https://cloud.google.com/nat/docs/troubleshooting#reduce-ports) otherwise increase
+       the `ips` value (section 1)
+
+{{% notice warning %}}
+Increasing the number of IPs is a safe operation; the existing connections won't be affected, however, decreasing the
+value without draining the connections first will cause connection being terminated immediately.
+See [Impact of tuning NAT configurations on existing NAT connections](https://cloud.google.com/nat/docs/tune-nat-configuration#impact-nat-tuning-existing-conns)
+for further details.
+{{% /notice %}}
+
+### NAT Gateway provisioning/updates failures
+
+```
+Error: Error when reading or editing Address: googleapi: Error 400: External address used for NAT cannot be deleted., badRequest
+```
+
+During updates to your `network.public_nat_gateway.ips` configuration when you try to remove already allocated IP address the
+update will fail. To decrease the number of allocated IPs, please drain it first then remove it from NAT Gateway
+manually before running IAC tool.
+Follow [Decrease allocated number of IP addresses](../nat-gateway#decrease-allocated-number-of-ip-addresses).
+
+### NAT Gateway high error count in logs
+
+NAT Gateway will only log errors related to packet drops because no port was available for NAT. To investigate and
+resolve, follow below:
+
+1. Increase the log level to `ALL` (if not already on this level) to get more details about successful connections (see
+   if any of errored connections are successful)
+2. If high errors count on packets send, check the trend of packet drops per reason in `platform-monitoring/NAT Gateway`
+   Grafana dashboard, for
+   `OUT_OF_RESOURCES` reason
+   follow [Packets dropped with reason: out of resources](https://cloud.google.com/nat/docs/troubleshooting#insufficient-ports)
+   {{% notice note %}}
+   We use manual NAT IP address assignment with dynamic port allocation
+   {{% /notice %}}
+
+### NAT Gateway high number of received packet drops
+
+{{% notice note %}}
+A Cloud NAT gateway drops an ingress data packet if the connection tracking table doesn't contain any entry for the
+connection. Those can be due to timeouts or external endpoint trying to establish a connection. Higher number than usual
+might not indicate any degradation of any services.
+{{% /notice %}}
+
+1. Check long window trend of received packet drop rate in `platform-monitoring/NAT Gateway` Grafana dashboard.
+   Establish which VM/pod is experiencing the highest drops, then validate it is a genuine failure.
+   For genuine failures,
+   see [Dropped received packets](https://cloud.google.com/nat/docs/troubleshooting#cdropped-packets) for hints on how
+   to resolve.

--- a/content/platform/troubleshooting.md
+++ b/content/platform/troubleshooting.md
@@ -186,11 +186,11 @@ kubectl describe gateway traefik -n platform-ingress
                network bandwidth, then check which pod belongs to that namespace in `Network Bandwith` graph in
                `platform-monitoring/Kubernetes/Views/Pods`.
         2. [Optional] Enable NAT Gateway logging if not already enabled. Logging provides more detailed information on
-           existing connections. To enable logs update `network.public_nat_gateway.logging` value to one of `ERRORS_ONLY`,
+           existing connections. To enable logs update `network.publicNatGateway.logging` value to one of `ERRORS_ONLY`,
            `TRANSLATIONS_ONLY`, `ALL`:
            ```
            network:
-             public_nat_gateway:
+             publicNatGateway:
                logging: TRANSLATIONS_ONLY - update to desired logging level
            ```
            See [Configure logging](https://cloud.google.com/nat/docs/monitoring) for log level explanation.
@@ -208,26 +208,26 @@ kubectl describe gateway traefik -n platform-ingress
    `environments/<env_name>/config.yaml` file:
    ```
    network:
-     public_nat_gateway:
-       ips: <number of IP's allocated> - increase this value to desired number of IP's
+     publicNatGateway:
+       ipCount: <number of IP's allocated> - increase this value to desired number of IP's
    ```
    Release the change and validate that port utilisation went down below 70%.
 
 2. Do you allocate too many min ports per VM?
     1. Go to Grafana `platform-monitoring/NAT Gateway` dashboard and validate allocated ports per VM against used ports
        per VM. Ensure to extend time span to take into account all traffic spikes. If most of the time ports are being
-       allocated but not used you can decrease the `min_ports_per_vm` setting in `environments/<env_name>/config.yaml`
+       allocated but not used you can decrease the `minPortsPerVm` setting in `environments/<env_name>/config.yaml`
        file:
        ```
        network:
-         public_nat_gateway:
-           min_ports_per_vm: <min number of ports allocated to single VM> - decrease this value to release ports
+         publicNatGateway:
+           minPortsPerVm: <min number of ports allocated to single VM> - decrease this value to release ports
        ```
        See [Choose a minimum number of ports per VM](https://cloud.google.com/nat/docs/tune-nat-configuration#choose-minimum)
        for further details.
     2. If all ports are utilised, check if you
        can [Reduce your port usage](https://cloud.google.com/nat/docs/troubleshooting#reduce-ports) otherwise increase
-       the `ips` value (section 1)
+       the `ipCount` value (section 1)
 
 {{% notice warning %}}
 Increasing the number of IPs is a safe operation; the existing connections won't be affected, however, decreasing the
@@ -242,7 +242,7 @@ for further details.
 Error: Error when reading or editing Address: googleapi: Error 400: External address used for NAT cannot be deleted., badRequest
 ```
 
-During updates to your `network.public_nat_gateway.ips` configuration when you try to remove already allocated IP address the
+During updates to your `network.publicNatGateway.ipCount` configuration when you try to remove already allocated IP address the
 update will fail. To decrease the number of allocated IPs, please drain it first then remove it from NAT Gateway
 manually before running IAC tool.
 Follow [Decrease allocated number of IP addresses](../nat-gateway#decrease-allocated-number-of-ip-addresses).


### PR DESCRIPTION
- runbook for alerts
- troubleshooting guide
- nat gateway feature docs

Destroying env:
There is no way of automatically destroying the IP address allocated to NAT Gateway. This is done in purpose as it is easy to remove the keyword from env config: publicNatGateway. When this is removed and we don't have that check, tf will release that allocated public IP. In consequence when you put it back, new IP might be allocated. Causing all clients to update their allowlists (and this might not be quick, so prod might be broken for a while). Therefore we don't allow to destroy it, tf will fail if you remove this keyword. The only way to destroy is to go and remove that IP from NAT Gateway. Put docs for that in [tech-docs](https://github.com/coreeng/core-platform-docs/pull/79/files#diff-7f55a24e25e42bf4bd5f53171341e301275974a76d221073b41b1875a551acce)