### PR TITLE
Rebrand from Developer Platform to Core Platform

### DIFF
--- a/content/changelogs/_index.md
+++ b/content/changelogs/_index.md
@@ -11,7 +11,7 @@ Click the links to go to each section.
 
 ## Changelogs
 
-### [Developer Platform](developer-platform.md)
+### [Core Platform](core-platform.md)
 
 ### [Path to Production](p2p.md)
 

--- a/content/changelogs/core-platform.md
+++ b/content/changelogs/core-platform.md
@@ -1,5 +1,5 @@
 +++
-title = "Developer Platform"
+title = "Core Platform"
 weight = 1
 chapter = false
 pre = ""


### PR DESCRIPTION
Replaces all references of Developer Platform with Core Platform.