### PR TITLE
Update platform-ingress docs

### DIFF
--- a/src/content/application/how-tos/ingress-with-whitelist.mdx
+++ b/src/content/application/how-tos/ingress-with-whitelist.mdx
@@ -1,6 +1,6 @@
 import { Callout } from "nextra/components";
 
-# Create Ingress with IP Whitelisting
+# Create Ingress with IP Allowlisting
 
 <Callout type="warning">This uses beta features in the platform and breaking changes may occur in the future</Callout>
 
@@ -11,7 +11,7 @@ import { Callout } from "nextra/components";
   will be deprecated in the future.
 </Callout>
 
-Create a `middleware.traefik.io` object to [whitelist IP addresses](https://doc.traefik.io/traefik/middlewares/http/ipwhitelist/):
+Create a `middleware.traefik.io` object to [allowlist IP addresses](https://doc.traefik.io/traefik/reference/routing-configuration/http/middlewares/ipallowlist/):
 
 ```yaml
 apiVersion: traefik.io/v1alpha1
@@ -20,9 +20,9 @@ metadata:
   name: <middlewareName>
   namespace: <middlewareNamespace>
 spec:
-  ipWhiteList:
+  ipAllowList:
     ipStrategy:
-      depth: 2 # depth is required as request is forwarded from load balancer. See https://doc.traefik.io/traefik/middlewares/http/ipwhitelist/#ipstrategydepth for more details
+      depth: 2 # request is forwarded from load balancer (X-Forwarded-For). Depth is counted from the right.
     sourceRange:
       - <ip-address>
       - <ip-address>
@@ -58,7 +58,7 @@ spec:
             pathType: ImplementationSpecific
 ```
 
-After you apply this, only users with whitelisted IPs will be able to use that ingress URL.
+After you apply this, only users with allowlisted IPs will be able to use that ingress URL.
 
 ## Debugging
 
@@ -70,6 +70,6 @@ To validate that your Middleware has been applied successfully, check the Traefi
 
 ### Logs
 
-Check traefik logs to see whether request is being whitelisted:
+Check traefik logs to see whether request is being allowlisted:
 
 ![Traefik Logs](/images/app/how-to/traefik-logs.png)

--- a/src/content/platform/how-tos/traefik.mdx
+++ b/src/content/platform/how-tos/traefik.mdx
@@ -1,6 +1,6 @@
-# Access the Traefik Dashboard
+# Access the Traefik dashboard
 
 
-You can use the Traefik Dashboard to review e.g. the configuration of HTTP middleware in the platform.
+You can use the Traefik dashboard to review e.g. the configuration of HTTP middleware in the platform.
 
-It is located at `https://traefik-dashboard.{{ internalServices.domain }}/dashboard/`
+It is located at `https://traefik.{{ internalServices.domain }}/dashboard/`

--- a/src/content/platform/managing-environments.mdx
+++ b/src/content/platform/managing-environments.mdx
@@ -106,21 +106,6 @@ This will attempt to initialize an environment called `dev`, as before, the scri
 
 ### Manual Steps
 
-#### Brand
-
-The IAP Brand needs to be manually created before deploying the Core Platform.
-After running the environment creation. Get the project id under the new environments folder
-then run:
-
-```shell
-PLATFORM_ADMIN_GROUP=???
-PROJECT=???
-gcloud iap oauth-brands create --application_title="Core Platform" --support_email="$PLATFORM_ADMIN_GROUP" --project $PROJECT
-```
-
-> ![WARNING]
-> The person executing this much be an owner of the $PLATFORM_ADMIN_GROUP
-
 #### DNS Delegation
 
 See [DNS Delegation](./dns) and [Identity Provider Login](./internal-services)

--- a/src/content/platform/troubleshooting.mdx
+++ b/src/content/platform/troubleshooting.mdx
@@ -123,7 +123,7 @@ kubectl logs -f deployment/traefik -n platform-ingress
 
 Logs:
 
-  { "level": "debug","middlewareName": "platform-ingress-ready-ipwhitelist@kubernetescrd","middlewareType": "IPWhiteLister","msg": "Accepting IP 86.160.248.78","time": "2024-08-07T22:03:23Z" }
+  { "level": "debug","middlewareName": "platform-ingress-ready-ipallowlist@kubernetescrd","middlewareType": "IPAllowLister","msg": "Accepting IP 86.160.248.78","time": "2024-08-07T22:03:23Z" }
 ```
 
 ##### Check Load Balancer logs


### PR DESCRIPTION
The platform-ingress implementation changed (Google-managed IAP OAuth client; Traefik v3 middleware naming), so the docs needed to match the current behavior and terminology.

- Remove the outdated manual “IAP OAuth Brand” creation step from environment provisioning docs (platform-ingress now uses the Google-managed OAuth client due to IAP OAuth Admin API deprecation).
- Update the “ingress with whitelist” how-to to use Traefik `ipAllowList` and allowlist terminology (and point to the current Traefik docs).
- Refresh troubleshooting/log examples to refer to IPAllowList instead of deprecated IPWhiteList.
- Tweak changelog wording from “whitelist” to “allowlist” for consistency.
