### PR TITLE
docs: add PT-307 pulse reflection feedback changelog entry

### DIFF
--- a/src/content/changelogs/p2p.mdx
+++ b/src/content/changelogs/p2p.mdx
@@ -12,6 +12,10 @@ To learn more about it, check our [P2P documentation.](/p2p)
   more strict as that one will also be overridden with the new version on each release, like `v1.1`.
 </Callout>
 
+## v1.6.110
+
+- Add embedded user feedback for Pulse reflections — users can now rate and comment on reflections after completion; managers can view, search, filter, and action feedback in a new Feedback tab by @user
+
 ## v1.6.109
 
 - Update actions by @kkonstan


### PR DESCRIPTION
Adds the changelog entry for PT-307 — embedded user feedback for Pulse reflections.

After completing a reflection, users can now rate (1–5 stars) and comment on it. Managers can view, search, filter, and action submitted feedback in a new Feedback tab in the Reflection Manager.