### PR TITLE
docs: p2p v1.6.110 changelog entry

### DIFF
--- a/src/content/changelogs/p2p.mdx
+++ b/src/content/changelogs/p2p.mdx
@@ -12,6 +12,10 @@ To learn more about it, check our [P2P documentation.](/p2p)
   more strict as that one will also be overridden with the new version on each release, like `v1.1`.
 </Callout>
 
+## v1.6.110
+
+- Fix broken pipe in version workflow by @jescard-tamer-cecg
+
 ## v1.6.109
 
 - Update actions by @kkonstan


### PR DESCRIPTION
Adds changelog entry for v1.6.110 — fixes intermittent broken pipe in p2p version workflow.