### PR TITLE
chore: sync docs P2P workflow inputs

### DIFF
--- a/.github/workflows/core-platform-docs-extended-test.yaml
+++ b/.github/workflows/core-platform-docs-extended-test.yaml
@@ -13,6 +13,7 @@ jobs:
     uses: coreeng/p2p/.github/workflows/p2p-get-latest-image-extended-test.yaml@v1
     with:
       image-name: core-platform-docs
+      tenant-name: core-platform-docs
 
   extendedtests:
     needs: [get-latest-version]
@@ -21,6 +22,7 @@ jobs:
       env_vars: ${{ secrets.env_vars }}
     with:
       app-name: core-platform-docs
+      tenant-name: core-platform-docs
       version: ${{ needs.get-latest-version.outputs.version }}
       version-prefix: v
       working-directory: ./

--- a/.github/workflows/core-platform-docs-fast-feedback.yaml
+++ b/.github/workflows/core-platform-docs-fast-feedback.yaml
@@ -29,6 +29,7 @@ jobs:
       env_vars: ${{ secrets.env_vars }}
     with:
       app-name: core-platform-docs
+      tenant-name: core-platform-docs
       version: ${{ needs.version.outputs.version }}
       working-directory: ./
 

--- a/.github/workflows/core-platform-docs-prod.yaml
+++ b/.github/workflows/core-platform-docs-prod.yaml
@@ -12,6 +12,7 @@ jobs:
     uses: coreeng/p2p/.github/workflows/p2p-get-latest-image-prod.yaml@v1
     with:
       image-name: core-platform-docs
+      tenant-name: core-platform-docs
 
   prod:
     needs: [get-latest-version]
@@ -20,6 +21,7 @@ jobs:
       env_vars: ${{ secrets.env_vars }}
     with:
       app-name: core-platform-docs
+      tenant-name: core-platform-docs
       version: ${{ needs.get-latest-version.outputs.version }}
       version-prefix: v
       working-directory: ./


### PR DESCRIPTION
## Summary
- add missing `tenant-name` inputs to the docs reusable P2P workflow calls
- align fast-feedback, extended-test, and prod with the current template workflow shape
- ensure the reusable workflow calls use the same app and tenant naming inputs consistently